### PR TITLE
Reformat & un-draft the Uses page

### DIFF
--- a/content/uses.md
+++ b/content/uses.md
@@ -2,26 +2,24 @@
 title: "Uses"
 date: 2019-06-01T20:27:59-04:00
 slug: "uses"
-draft: true
 ---
 
-# Tools I Use
+## Tools I Use
 
 (Inspired by [awesome-uses](https://github.com/wesbos/awesome-uses))
 
-## Development Tools
+### Development Tools
 
 * Visual Studio Code (or Jetbrains IDEA, or Vim. But mostly VSCode)
 * Konsole
 * Zsh (+ antibody to manage plugins)
 
-## Running
+### Running
 
-* Garmin Forerunner 405. I've had it for ~6 years, and it's starting to 
+* Garmin Forerunner 405. I've had it for ~6 years, and it's starting to
   get pretty beat up. Still works great, though!
-* Saucony Freedom ISO. I've gone through 4 (?) pairs of these, after switching 
+* Saucony Freedom ISO. I've gone through 4 (?) pairs of these, after switching
   away from Hoka Odysseys (which I found I was wearing through too quickly).
-* [Strava](https://strava.com). Strava has, in my opinion, better analytics even 
-  at the free level than Garmin does, and it really benefits from the community 
-  aspect of running.
-
+* [Strava](https://strava.com). Strava has, in my opinion, better analytics
+  even at the free level than Garmin does, and it really benefits from the
+  community aspect of running.


### PR DESCRIPTION
Because "Uses" was a draft but still appeared on the main menu, it
was basically a dead link. I'll need to look into why the checker didn't
catch that.

Also does some small Markdown reformatting changes, to change the
header levels on the page and do some re-indenting.

This page is nowhere near done, I'm just unbreaking a link. I'll
actually finish this later.