### PR TITLE
Add author's note on She-Ra post

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,9 +3,9 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: cibuilds/hugo:0.58.2
+      - image: &docker_image cibuilds/hugo:0.76.5
     steps:
-      - add_ssh_keys:
+      - add_ssh_keys: &fingerprints
           fingerprints:
             - "81:36:b5:49:9a:2c:b4:c2:2e:89:dc:c6:46:74:8b:9c"
       - checkout
@@ -14,16 +14,12 @@ jobs:
       - run:
           name: "Build site"
           command: HUGO_ENV=production hugo -v
-      # - run:
-      #     name: "Test website"
-      #     command: htmlproofer public --allow-hash-href --check-html --empty-alt-ignore --disable-external
   deploy:
     docker:
-      - image: cibuilds/hugo:0.55.6
+      - image: *docker_image
     steps:
       - add_ssh_keys:
-          fingerprints:
-            - "81:36:b5:49:9a:2c:b4:c2:2e:89:dc:c6:46:74:8b:9c"
+          <<: *fingerprints
       - checkout
       - run: git submodule sync
       - run: git submodule update --init

--- a/config.toml
+++ b/config.toml
@@ -3,6 +3,9 @@ languageCode = "en-us"
 title = "Peter Teixeira"
 theme = "hugo-coder"
 
+[markup.goldmark.renderer]
+unsafe = false
+
 [params]
 author = "Peter Teixeira"
 description = "Random Thoughts"
@@ -13,22 +16,22 @@ hideCopyright = true
 
 [[params.social]]
 name = "GitHub"
-icon = "fab fa-github"
+icon = "fa fa-github"
 weight = 1
 url = "https://github.com/PtrTeixeira"
 [[params.social]]
 name = "Strava"
-icon = "fab fa-strava"
+icon = "fa fa-bicycle"
 weight = 2
 url = "https://www.strava.com/athletes/23454143"
 [[params.social]]
 name = "LinkedIn"
-icon = "fab fa-linkedin"
+icon = "fa fa-linkedin"
 weight = 3
 url = "https://www.linkedin.com/in/PtrTeixeira"
 [[params.social]]
 name = "Twitter"
-icon = "fab fa-twitter"
+icon = "fa fa-twitter"
 weight = 4
 url = "https://www.twitter.com/PeterTeixeira9"
 
@@ -39,14 +42,14 @@ url = "https://www.twitter.com/PeterTeixeira9"
     [[languages.en.menu.main]]
     name = "Uses"
     weight = 1
-    url = "/uses/"
+    url = "uses/"
 
     [[languages.en.menu.main]]
     name = "About"
     weight = 2
-    url = "/about/"
+    url = "about/"
 
     [[languages.en.menu.main]]
     name = "Posts"
     weight = 3
-    url = "/posts/"
+    url = "posts/"

--- a/content/posts/legend-of-korra.md
+++ b/content/posts/legend-of-korra.md
@@ -10,9 +10,7 @@ externalLink = ""
 series = []
 +++
 
-<center>
-{{< figure src="/me/images/legend-of-korra-overlooking-city.jpg" alt="Korra looking out over Republic City" >}}
-</center>
+{{< figure src="/me/images/legend-of-korra-overlooking-city.jpg" alt="Korra looking out over Republic City" class="centered">}}
 
 _Avatar: Legend of Korra_ is best known for not being _Avatar: The Last Airbender_. It received a certain amount of hate when it came out, and has long been viewed as greatly overshadowed by its predecessor. That view is both accurate and somewhat unfair. Legend of Korra is a very different show than _The Last Airbender_, with different conflicts and a dramatically different view of trauma, especially emotional trauma, than its predecessor.
 
@@ -20,9 +18,7 @@ _The Last Airbender_ spends little time focusing on the personal cost of trauma.
 
 Korra is a very different Avatar than Aang. When we meet her In the White Lotus camp we see a young woman, powerfully muscled where Aang was slight, brazen where Aang was cautious, and gifted in all the elements except Aang’s own. And unlike Aang, who was hesitant to accept his responsibilities as the Avatar, Korra defines herself by them. Her very first words in the show, then little more than a toddler, are “I'm the Avatar, you gotta deal with it!” - a stark contrast to Aang’s flight from the Air Temple after he learns he’s the Avatar. When Korra arrives in Republic City, practically the  first thing Korra does is find some thugs to beat up. She is cocksure and self-righteous and - in fairness - brave and kind-hearted. Korra sees herself first and foremost as the Avatar - physically powerful and a gifted bender, and dedicated to using those gifts to help people.
 
-<center>
-{{< figure src="/me/images/legend-of-korra-fighting-criminals.jpg" alt="Korra preparing to beat up some gangsters" >}}
-</center>
+{{< figure src="/me/images/legend-of-korra-fighting-criminals.jpg" alt="Korra preparing to beat up some gangsters" class="centered">}}
 
 That self image is a large part of why her conflict with Amon in season one affected her so powerfully. Amon’s ability to take away bending preyed on Korra’s fear of weakness and insufficiency. After Amon demonstrates his ability in “The Revelation,” Korra has a nightmare about Amon taking away her bending. It ends with Amon saying “After I take your bending away, you’ll be nothing.” Her nightmare demonstrates her fear of being unable to help people as the  Avatar. More generally, Amon’s equalist movement is also a threat to Korra’s self image. Amon’s argument, repeated by his lieutenants, is that the era of benders is over. In Amon’s new world, the Avatar is nothing more than the relic of a bygone era. Korra tries to confront her fears head-on by challenging Amon to a duel in “The Voice in the  Night,” but it winds up backfiring. In a scene that plays out much like her nightmare, Korra is ambushed by Amon and his chi-blockers and quickly defeated. Worse than her physical defeat, Amon dismisses her, telling her that while he could take away her bending easily, his plans are bigger than she is.
 
@@ -34,9 +30,7 @@ Defeat, even defeat at such a scale, isn’t why _Legend of Korra_ is distinct f
 
 Korra ultimately needs to be healed three times over the course of season four. The time is with Katara, in the Southern Water Tribe, and only addresses the physical symptoms of Korra’s trauma. It actually looks a lot like physical therapy in the real world. It also introduces some of the  major themes of Korra’s gradual healing. Katara can’t do very much to help Korra - Korra needs to actively participate in her own healing, and put a lot of work into it. As much as Korra wants to, and as much as her gradual progress frustrates her, Korra can’t get better by just resenting where she is. When she leaves Katara and the Southern Water Tribe, Korra has regained her mobility, but is still physically weaker and still emotionally traumatized by her fight with Zaheer - a fact which is very clearly symbolized by Korra’s vision of herself from that fight.
 
-<center>
-{{< figure src="/me/images/legend-of-korra-korra-alone.png" alt="Korra's reflection in a broken mirror" >}}
-</center>
+{{< figure src="/me/images/legend-of-korra-korra-alone.png" alt="Korra's reflection in a broken mirror" class="centered">}}
 
 In her second healing with Toph, Korra needs to more directly engage with the  physical effects of her trauma. Korra needs to remove the  remaining metal poison from her body before she can return to her strength. More importantly, Korra herself needs to do it. Within the show itself, Korra is holding onto her trauma too tightly for Toph to heal her, so Korra needs to take responsibility for her own healing. Metaphorically, it's a repetition of Katara’s words during Korra’s physical therapy - other people will be able to help her heal, but Korra will need to put in a lot of the work on her own.
 
@@ -48,9 +42,7 @@ I do want to make one more, unrelated comment. Now, in 2020, the relationship be
 
 There are many possible criticisms for how the show handled their relationship - that it was underdeveloped, that Konietzko and DiMartino yielded too readily to pressure from the network, that its influence was small because _Legend of Korra_ had been pulled from television by season 4 and was broadcast exclusively online. Many of them are true. But that’s not the point.
 
-<center>
-{{< figure src="/me/images/legend-of-korra-korra-and-asami.jpg" alt="Korra and Asami holding hands, facing each other" >}}
-</center>
+{{< figure src="/me/images/legend-of-korra-korra-and-asami.jpg" alt="Korra and Asami holding hands, facing each other" class="centered">}}
 
 My coping mechanism thus far in quarantine has been watching more recent animated television shows principally geared to children - _She-Ra and the Princesses of Power_, _Kipo and the Age of Wonderbeasts_, _The Owl House_, _Steven Universe_. I don’t really have the words to talk about how much it matters to have shows that depict LGBT content so positively. It matters that Catra and Adora kissed. It matters that Willow has two dads. It matters that Stevonnie uses they/them pronouns. And it matters that Benson got to say “I’m gay” on television. It matters because kids who watch the show get to have heroes that feel the way they do. It matters that they get to have a language to describe themselves. They get to believe that they have a right to exist and that they are valid.
 

--- a/content/posts/she-ra-and-the-princesses-of-power.md
+++ b/content/posts/she-ra-and-the-princesses-of-power.md
@@ -10,9 +10,14 @@ externalLink = ""
 series = []
 +++
 
-<center>
-{{< figure src="/me/images/she_ra_header.jpg" alt="She-Ra Cinematic Poster" >}}
-</center>
+{{< figure src="/me/images/she_ra_header.jpg" alt="She-Ra Cinematic Poster" class="centered">}}
+
+{{< aside >}}
+Author's Note: This was the first piece of long-form writing I've done in about two years, and the first piece
+of writing about literature that I've done in about seven years. It reads like a mediocre high-school essay, because
+it basically is. I've written several pieces since, which I like to think read a little nicer than this. I will certainly
+re-watch <emph>She-Ra</emph>, probably in the near future, and when I do that I'll come back to this post and re-write it.
+{{< /aside >}}
 
 _She-Ra and the Princesses of Power_ isn’t terribly subtle in its moralizing. At one point in S5E12 Princess Entrapta tells Hordak that it's his differences from his hive-mind brothers that make him special. It also doesn’t need to be. _She-Ra_ is grounded on how well the characters are developed and humanized, from the four-legged non-verbal robot Emily to the Best Friends Squad at the center of the show to the villains. All of the antagonists of the show, from the low-ranking foot soldiers of Lonnie, Rogelio, and Kyle to Hordak, the primary antagonist for the  first four seasons, are deeply developed. The development of the antagonists, their internal conflicts and their motivations, help draw me into the show.
 
@@ -20,17 +25,13 @@ I spent a while during season 5 wondering whether Catra would earn her redemptio
 
 I’m still not sure that I would have forgiven here. But I didn’t grow up with her, like Adora did, and more importantly I’m not as good a person as Adora. Catra didn’t have an easy path to walk for forgiveness. The princesses resented her and neither changing nor apologizing were in her nature. Yet she did both. Catra put in the  work to change herself, to move past her anger and her abandonment issues, and become friends with the  princesses. What sold me, in the end, was Catra’s apology to Scorpia. She was forced to acknowledge how badly she had treated Scorpia and give Scorpia the opportunity to reject her. That, more than anything that Catra did for Adora, convinced me that she had changed as a person.
 
-<center>
-{{< figure src="/me/images/catra_adora_melog.jpg" alt="Catra watching Adora and Melog sleep" >}}
-</center>
+{{< figure src="/me/images/catra_adora_melog.jpg" alt="Catra watching Adora and Melog sleep" class="centered">}}
 
 The addition of Melog also helped with her characterization. Catra, as much as she put into changing over the  course of season 5, still couldn’t express emotions easily or let herself be vulnerable with people. She also didn’t have anyone that she could be vulnerable with - she couldn’t talk about her feelings with Adora, and she wouldn’t talk about them with any over the  other princesses. Without Melog, she would have been as isolated among the princesses as she had been with the Horde. Instead, she had a way to express her emotion - Melog licking Perfuma’s face when Perfuma helped her open up or sleeping on Adora’s stomach. Even more important than mirroring Catra’s emotions, Melog gave Catra someone to talk to. She forces Catra to put her emotions into words when she leaves Adora in S5E11. Catra spent four seasons only rarely showing chinks in her emotional armor. Her vulnerability in the final season builds on those rare moments to show a much deeper, more human character.
 
 Although Double Trouble is Catra’s confidant for much of Season 4, they have a very different emotional involvement. Catra has a deep emotional involvement in showing up Adora, which translates to her support for the Horde. Double Trouble has no interest in whether the Rebellion or the Horde win. Their stated motivation is money, but their real interest always seems to be in the performance itself. Double Trouble is a shapeshifter whose principal love always seems to be getting into their roles and deceiving those around them. They change sides when it is convenient for them, deceiving Catra and Hordak with just as much glee as they had previously deceived the Princess Alliance. There’s a certain amount of casual cruelty in that. Catra thought she had finally found a peer in Double Trouble, someone whom she could think of more as her equal than Scorpia. When Double Trouble betrayed her, so soon after Scorpia had left her, Double Trouble hurt Catra very deeply. But Double Trouble always comes off as more amoral than immoral, more interested in playing their roles than in any larger purpose.
 
-<center>
-{{< figure src="/me/images/catra_double-trouble.jpg" alt="Catra and Double Trouble" >}}
-</center>
+{{< figure src="/me/images/catra_double-trouble.jpg" alt="Catra and Double Trouble" class="centered">}}
 
 That is, ultimately, the most distinctive part of Double Trouble - how deeply their shape-shifting defines who they are. Shape-shifting isn’t just an ability they have, it’s a deeply ingrained part of their character.one of the smaller but more important ways this comes across is in Double Trouble’s gender identity. Double Trouble is nonbinary, as are showrunner Noelle Stevenson and Double Trouble’s voice actor, Jacob Tobia. They have both talked about shapeshifting as a metaphor for their own experiences as non-binary. Stevenson has cited Zam Wessell, the shape-shifting bounty hunter from Star Wars: Attack of the Clones, as being a formative experience for their own gender identity. Tobia has talked more generally about shape-shifting as a common experience for people who are trans or non-binary - “navig ating the world and shaping how we're putting on ourselves often to survive or to get by.” [^1] Perhaps more than any of the other characters in the show, Double Trouble’s abilities aren’t merely something that the character has. They’re a fundamental part of who they are.
 

--- a/content/posts/the-owl-house-s1.md
+++ b/content/posts/the-owl-house-s1.md
@@ -9,17 +9,13 @@ externalLink = ""
 series = []
 +++
 
-<center>
-{{< figure src="/me/images/the-owl-house-s1-title.jpg" alt="The Owl House poster" >}}
-</center>
+{{< figure src="/me/images/the-owl-house-s1-title.jpg" alt="The Owl House poster" class="centered">}}
 
 Luz’s relationship with her mother isn’t explored very much in the show, even though it’s such a central part of her motivations. The season ends with her voice memo to Camilla, and specifically with Luz telling her mother that she loves her. But Luz’s love for her mother is also deeply shadowed by her that she will disappoint her mother, or that she already has. “Enchanting Grom Fright” very clearly shows how Luz reacts to her mother’s consternation that she’s not at camp, that she’s holding a weapon. Camilla’s reactions are amped up, but not so different in tone than in “A Lying Witch and a Warden” when Luz is called to the principal’s office. Luz is proudly a “weirdo,” and hates the idea of conformity for its own sake. But she’s always done her best to temper that impulse on her mother’s behalf.
 
 The Boiling Isles is a brand new opportunity for her. Her first real interaction in the world in “A Lying Witch and a Warden” is to stick up for the “weirdos” and declare that no one should be punished for who they are. It’s hard not to read this as a specific rejection of the “Think Inside the Box” she narrowly avoided being sent to. The Boiling Isles also introduce her to Eda and King. Their affection for each other is specifically not conditioned on conformity. Eda specifically has no problem existing on the boundaries, resisting being indoctrinated by normal society at all costs. King likewise seems to live on the fringes, spending little effort to be part of the regular business of Bonesboro or the island as a whole. Eda is often exasperated by Luz’s antics, but she is always protective of Luz, rather than controlling. When Luz wants to go to the Covention or attend Hexside, Eda goes along with her, against her own inclinations. Despite Eda’s relatively harsh perspective on traditional Hexside schooling, she puts a great deal of work into getting Luz enrolled and prepared for school. This is reflected in how Luz thinks about Eda in “Enchanting Grom Fight.” Luz’s fear about Eda is about adequacy, rather than for Camilla, where it’s about conformity. The two fears parallel each other very closely, with a very fundamental difference in how Luz feels about them.
 
-<center>
-{{< figure src="/me/images/the-owl-house-s1-eda.png" alt="Luz hugs Eda and King" >}}
-</center>
+{{< figure src="/me/images/the-owl-house-s1-eda.png" alt="Luz hugs Eda and King" class="centered">}}
 
 There’s a small parallel here with Willow. We don’t see much about Willow’s home life, but we do get one line from “I Was a Teenage Abomination” -
 
@@ -29,9 +25,7 @@ Willow’s parents put her in the Abomination track, and she has stayed in order
 
 Amity, of course, is the ultimate example of this trope. “Understanding Willow” makes it very clear how far her parent’s will go to control her life. They take control over everyone that she is friends with, threatening to prevent Willow’s acceptance to Hexside if Amity doesn’t stop being friends with her and befriend their hand-picked acquaintances instead. If Word of God can be accepted as canon, Amity’s parents went so far as to control her hair color. Showrunner Dana Terrace indicated that Amity was required to dye her hair green to color-coordinate with her older siblings. It’s also easy to imagine a young Amity fearing to be anything less than perfect, given her Edric and Emira’s significant talents with magic. Amity has spent her whole life in the  shadow of her parents, friendless and emotionally restricted. “Lost in Language” makes it clear that Amity is very lonely. The door to her secret hideaway is a book titled _The Lone Witch & Secret Room_, and the secret room itself seems like it’s not something that she would share with Boscha or her crew.
 
-<center>
-{{< figure src="/me/images/the-owl-house-s1-amity.png" alt="Amity reassures Luz ahead of the Grom fight" >}}
-</center>
+{{< figure src="/me/images/the-owl-house-s1-amity.png" alt="Amity reassures Luz ahead of the Grom fight" class="centered">}}
 
 Luz is Amity’s fresh start, in the same way that the Boiling Isles is Luz’s. Amity’s initial impression of Luz is, of course, not great. Luz initially costs Amity her top-student status, then the respect of the Bonesboro community in the aftermath of the duel in “Covention.” But the  aftermath of the duel in “Covention” also shows her a better side of Luz. Luz shows that she is hard-working and cares deeply about getting better at magic - traits that she shares with Amity. But where Amity is emotionally restricted, Luz is open and friendly. Luz makes an effort to get to know Amity and to befriend her. Luz’s dedication to Willow in “Understanding Willow” and to Amity herself in “Enchanting Grom Fight” stands in contrast to how Amity treats Willow after that birthday. The  Boiling Isles is liberating for Luz because it gives her a new support system for her to grow into herself. Luz personally provides support for Amity as a genuine friend for her, but she also provides an example of what a more free version of Amity might look like.
 

--- a/layouts/shortcodes/aside.html
+++ b/layouts/shortcodes/aside.html
@@ -1,0 +1,3 @@
+<aside style="font-style: italic;">
+{{ .Inner | markdownify }}
+</aside>


### PR DESCRIPTION
Adds a note saying that I know the She-Ra post as it stands is pretty
bad.

This is a way, way larger PR than I wanted this to be. This was supposed
to be a very, very small pr of maybe just the note. But I had updated
the hugo binary in the meantime, which brought in some significant
breaking changes. The main compensation for those was updating my inline
HTML into stuff that wasn't that.

Also updated the theme, which *also* had some breaking changes
(specifically with regard to a new icon font).